### PR TITLE
--debug: More details on would-be request, clarify it's not sent

### DIFF
--- a/lib/trigger.js
+++ b/lib/trigger.js
@@ -44,29 +44,33 @@ var trigger = (argv) => {
 
         console.log(`Git commit: ${gitCommitHash}`);
 
-        console.log('Calling Travis...');
+        var payload = {};
+        payload.message = "Triggered by upstream build of " + process.env.TRAVIS_REPO_SLUG;
+        payload.branch = branch;
+        payload.config = argv.config
+
+        var headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Travis-API-Version": "3",
+            "Authorization": `token ${token}`,
+        }
 
         if (debug) {
-            console.log(debug_message('argv =>', JSON.stringify(argv)));
+            console.log(debug_message('argv:', JSON.stringify(argv, null, 4)));
             console.log(debug_message(`endpoint: https://api.travis-ci.${accounttype}/repo/${owner}%2F${repo}/requests`));
-            console.log(debug_message(`token: ${token}`));
+            console.log(debug_message('headers:', JSON.stringify(headers, null, 4)));
+            console.log(debug_message('payload:', JSON.stringify(payload, null, 4)));
+            console.log('Omit --debug to perform request.');
         } else {
-            var payload = {};
-            payload.message = "Triggered by upstream build of " + process.env.TRAVIS_REPO_SLUG;
-            payload.branch = branch;
-            payload.config = argv.config
-
+            console.log('Calling Travis...');
             got.post(`https://api.travis-ci.${accounttype}/repo/${owner}%2F${repo}/requests`, {
-                    headers: {
-                        "Content-Type": "application/json",
-                        "Accept": "application/json",
-                        "Travis-API-Version": "3",
-                        "Authorization": `token ${token}`,
-                    },
+                    headers: headers,
                     body: JSON.stringify({request : payload})
                 })
                 .then((res) => {
-                    console.log(`Triggered build of ${owner}/${repo}`);
+                    console.log(`Triggered build of ${owner}/${repo}.`);
+
                 })
                 .catch((err) => {
                     console.error(err);


### PR DESCRIPTION
I started doing requests from UI, now trying to automate with trigger-travis,
so naturally I enabled --debug to see what's going on.
It says `Calling Travis...`, logs some details, and ...nothing happens :-(

So after reading the source, turns out that's by design :-)
This PR makes it clear it did not perform request and you should omit `--debug` for that, and dumps more info on request it was going to perform.

Example debug output:
```
Fetching Git commit hash...
0ac0a24ad49a1ae6dd587f2f180b14391c5f785e
Git commit: 0ac0a24ad49a1ae6dd587f2f180b14391c5f785e
argv: {
    "repo": "manageiq-providers-openshift",
    "owner": "cben",
    "token": "stMM5l5DK0nZP4zZEzzFEQ",
    "branch": "kubeclient-3.0",
    "pro": false,
    "debug": true,
    "config": "\nenv:\n- INJECT_GEMS='{\"kubeclient\":{\"git\":\"https://github.com/abonas/kubeclient\",\"branch\":\"master\"},\"manageiq-providers-kubevirt\":{\"git\":\"https://github.com/cben/manageiq-providers-kubevirt\",\"branch\":\"kubeclient-3.0\"},\"image-inspector-client\":{\"git\":\"https://github.com/moolitayer/image-inspector-client\",\"branch\":\"master\"}}'\nbefore_install:\n- git clone https://github.com/patch-graph/gitjection\n"
}
endpoint: https://api.travis-ci.org/repo/cben%2Fmanageiq-providers-openshift/requests
headers: {
    "Content-Type": "application/json",
    "Accept": "application/json",
    "Travis-API-Version": "3",
    "Authorization": "token stMM5l5DK0nZP4zZEzzFEQ"
}
payload: {
    "message": "Triggered by upstream build of undefined",
    "branch": "kubeclient-3.0",
    "config": "\nenv:\n- INJECT_GEMS='{\"kubeclient\":{\"git\":\"https://github.com/abonas/kubeclient\",\"branch\":\"master\"},\"manageiq-providers-kubevirt\":{\"git\":\"https://github.com/cben/manageiq-providers-kubevirt\",\"branch\":\"kubeclient-3.0\"},\"image-inspector-client\":{\"git\":\"https://github.com/moolitayer/image-inspector-client\",\"branch\":\"master\"}}'\nbefore_install:\n- git clone https://github.com/patch-graph/gitjection\n"
}
Omit --debug to perform request.
```
Example output without `--debug` (unchanged):
```
Fetching Git commit hash...
0ac0a24ad49a1ae6dd587f2f180b14391c5f785e
Git commit: 0ac0a24ad49a1ae6dd587f2f180b14391c5f785e
Calling Travis...
Triggered build of cben/manageiq-providers-openshift
```

Also working on followup to print URL of triggered build...